### PR TITLE
handle comma separated value

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,9 @@ const register = function (server, options) {
 
     const getRemoteAddress = function (request) {
 
-        return request.headers['x-forwarded-for'] || request.info.remoteAddress;
+        const xFF = request.headers['x-forwarded-for'];
+
+        return xFF ? xFF.split(',')[0].trim() : request.info.remoteAddress;
     };
 
     server.decorate('request', 'remoteAddress', getRemoteAddress, { apply: true });

--- a/test/index.js
+++ b/test/index.js
@@ -54,4 +54,18 @@ lab.experiment('HapiRemoteAddress', () => {
 
         Code.expect(response.request.remoteAddress).to.equal('192.168.0.1');
     });
+
+    lab.test('it decorates the request with `remoteAddress` (x-forwarded-for with comma separated value)', async () => {
+
+        const response = await server.inject({
+            method: 'GET',
+            url: '/',
+            remoteAddress: '127.0.0.1',
+            headers: {
+                'x-forwarded-for': '192.168.0.1, 192.168.0.2'
+            }
+        });
+
+        Code.expect(response.request.remoteAddress).to.equal('192.168.0.1');
+    });
 });


### PR DESCRIPTION
according to Wikipedia, the value of `X-Forwarded-For` is not always a single IP address: https://en.wikipedia.org/wiki/X-Forwarded-For#Format, hence we need to handle the case when it has multiple comma separated value